### PR TITLE
Update the date when changing year or month in the sub viewMode

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -582,11 +582,12 @@
                   this._date.getUTCSeconds(),
                   this._date.getUTCMilliseconds()
                 );
+                this.set();
                 this.notifyChange();
               }
               this.showMode(-1);
               this.fillDate();
-              this.set();
+
               break;
             case 'td':
               if (target.is('.day')) {


### PR DESCRIPTION
The commit resolve an issue preventing the date to be update when changing month and year.
How to reproduce:
1. Open the datepicker end date
2. Click on the year and change it
3. Select the month

**Found**: The date does not change.
**Expectation**: The date should show the year and the selected month.

Internal ref: https://adespresso.atlassian.net/browse/BUGS-32
